### PR TITLE
feat: add client role authorization check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,6 +92,7 @@ jobs:
               --include-package-data=ksso \
               --disable-ccache \
               --onefile \
+              --include-data-file=ksso/failure_access_prohibited_message.html=ksso/failure_access_prohibited_message.html \
               --include-data-file=ksso/success_message.html=ksso/success_message.html \
               --output-dir="dist" \
               --output-filename=ksso-$os_name-$os_arch \
@@ -105,6 +106,7 @@ jobs:
               --macos-target-arch=arm64 \
               --disable-ccache \
               --onefile \
+              --include-data-file=ksso/failure_access_prohibited_message.html=ksso/failure_access_prohibited_message.html \
               --include-data-file=ksso/success_message.html=ksso/success_message.html \
               --output-dir="dist" \
               --output-filename=ksso-$os_name-$os_arch \
@@ -120,6 +122,7 @@ jobs:
               --macos-target-arch=x86_64 \
               --disable-ccache \
               --onefile \
+              --include-data-file=ksso/failure_access_prohibited_message.html=ksso/failure_access_prohibited_message.html \
               --include-data-file=ksso/success_message.html=ksso/success_message.html \
               --output-dir="dist" \
               --output-filename=ksso-$os_name-$os_arch \
@@ -131,6 +134,7 @@ jobs:
               --assume-yes-for-downloads \
               --disable-ccache \
               --onefile \
+              --include-data-file=ksso/failure_access_prohibited_message.html=ksso/failure_access_prohibited_message.html \
               --include-data-file=ksso/success_message.html=ksso/success_message.html \
               --output-dir="dist" \
               --output-filename=ksso-$os_name-$os_arch \

--- a/ksso/exceptions.py
+++ b/ksso/exceptions.py
@@ -1,0 +1,4 @@
+class KCError(Exception):
+    """Custom keycloak exception for errors."""
+
+    pass

--- a/ksso/failure_access_prohibited_message.html
+++ b/ksso/failure_access_prohibited_message.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Authentication Successful</title>
+  </head>
+
+  <body
+    style="
+      font-family: Arial, sans-serif;
+      background-color: #f8f9fa;
+      text-align: center;
+      margin-top: 50px;
+    "
+  >
+    <div
+      style="
+        display: inline-block;
+        padding: 20px;
+        border: 2px solid black;
+        border-radius: 10px;
+        background-color: #faebd7;
+        color: red;
+        font-size: 1.2em;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        max-width: 400px;
+        text-align: center;
+      "
+    >
+      <h2 style="margin-top: 0">
+        SSO Authorization Failed. You can't assume this client role.
+      </h2>
+      <p>You can safely close this window now.</p>
+    </div>
+  </body>
+</html>

--- a/ksso/failure_access_prohibited_message.html
+++ b/ksso/failure_access_prohibited_message.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>Authentication Successful</title>
+    <title>Authentication Failed!</title>
   </head>
 
   <body

--- a/ksso/main.py
+++ b/ksso/main.py
@@ -22,7 +22,6 @@ import webbrowser
 from queue import Queue
 from sys import exit
 
-import jwt
 import requests
 
 from ksso.aws import (
@@ -112,10 +111,6 @@ def main():
 
     # Wait for the token and session name to be available in the queue
     access_token, session_name = token_queue.get()
-    if os.environ.get("DEBUG"):
-        decoded_token = jwt.decode(access_token, options={"verify_signature": False})
-        print(decoded_token)
-
     # Assume AWS role using the obtained access token and session name
     credentials = assume_aws_role_with_keycloak_token(access_token, aws_role_arn, session_name)
 

--- a/ksso/server.py
+++ b/ksso/server.py
@@ -7,28 +7,33 @@ import jwt
 import requests
 from flask import Flask, redirect, request
 
+from ksso.exceptions import KCError
+
+
 # Use Nuitka/PyInstaller temp directory if bundled
 # If the script is running as a bundled executable (created by PyInstaller),
 # 'sys.frozen' is set to True, and 'sys._MEIPASS' provides the path to the
 # temporary directory where PyInstaller extracts bundled resources.
 # Otherwise, use the current working directory as the base path.
 def get_base_path():
-    if hasattr(sys, '_MEIPASS'):
+    if hasattr(sys, "_MEIPASS"):
         # PyInstaller-like temp folder (if used)
         return sys._MEIPASS
-    elif getattr(sys, 'frozen', False):  # Nuitka or PyInstaller binary
+    elif getattr(sys, "frozen", False):  # Nuitka or PyInstaller binary
         # Nuitka-compiled binary path
         return os.path.dirname(sys.executable)
-    elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
+    elif hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix:
         # Inside a venv
         return os.path.dirname(os.path.abspath(__file__))
     else:
         # Default to the script's directory
         return os.path.dirname(os.path.abspath(__file__))
 
+
 base_path = get_base_path()
 
 app = Flask(__name__)
+logger = logging.getLogger("error")
 
 # Suppress Flask logs as we want to output JSON text in the console
 # that is later on will be parsed by aws-vault via credentials process output
@@ -111,10 +116,41 @@ def callback():
         or decoded_token.get("sub")
     )
 
+    try:
+        resource_access = decoded_token.get("resource_access", False)
+        authorize_access(
+            access=resource_access,
+            client_id=app.config["CLIENT_ID"],
+            role=app.config["AWS_ROLE_ARN"],
+        )
+        app.token_queue.put((access_token, session_name))
+        html_file_path = os.path.join(base_path, "success_message.html")
+    except KCError as e:
+        logger.error(e)
+        app.token_queue.put(("AuthFailure", "AuthFailure"))
+        html_file_path = os.path.join(base_path, "failure_access_prohibited_message.html")
+
     # Pass token and session name to the main thread
-    app.token_queue.put((access_token, session_name))
-    html_file_path = os.path.join(base_path, "success_message.html")
     with open(html_file_path, "r") as file:
         html_content = file.read()
 
     return html_content
+
+
+def authorize_access(access: dict, client_id: str, role: str):
+    """
+    Validate that the client_id exists in the resource_access dictionary
+    and that the specified role is present in its roles list.
+    """
+    if not isinstance(access, dict):
+        raise KCError("Invalid resource_access structure of the access token")
+
+    if client_id not in access:
+        raise KCError(f"You're not authorized to access client ID {client_id}")
+
+    if role not in access[client_id].get("roles", []):
+        raise KCError(
+            f"You're not authorized to assume role {role} which is defined in Client ID {client_id}"
+        )
+
+    return True

--- a/ksso/server.py
+++ b/ksso/server.py
@@ -137,10 +137,15 @@ def callback():
     return html_content
 
 
-def authorize_access(access: dict, client_id: str, role: str):
-    """
-    Validate that the client_id exists in the resource_access dictionary
-    and that the specified role is present in its roles list.
+def authorize_access(access: dict, client_id: str, role: str) -> bool:
+    """Authorize the request.
+
+    Perform the check that the client_id exists in the resource_access dictionary
+    of the access_token and that the specified role is present in its roles list.
+
+    Returns:
+        bool: True  (the user should be granted access to the aws role)
+              False (the user should not be granted access to the aws role)
     """
     if not isinstance(access, dict):
         raise KCError("Invalid resource_access structure of the access token")


### PR DESCRIPTION
### Summary
JIRA: https://saritasa.atlassian.net/browse/SD-1092

- Add ability to check if user is authorized to access the KC client/role
- Such role should be granted to the KC user via KC group
  - To test simply remove the user from the group temporarily that grants the access to a one or more roles defined in the KC client

In the case of the failure the end-user will see this in the browser
![image](https://github.com/user-attachments/assets/6f8129d6-f259-4067-bc2b-26cb9df68d54)

```sh
➜ aws-vault exec client/keycloak/devops
 * Tip: There are .env files present. Install python-dotenv to use them.
Failed to assume role arn:aws:iam::111111:role/client-sso-administrators-role: InvalidIdentityToken - The ID Token provided is not a valid JWT. (You may see this error if you sent an Access Token)
aws-vault: error: exec: Failed to get credentials for client/keycloak/devops: running command "sso --json --client-id client-aws-devops --aws-role-arn arn:aws:iam::111111:role/client-sso-administrators-role": exit status 1
```